### PR TITLE
Patch 1

### DIFF
--- a/classes/CitationsParser.inc.php
+++ b/classes/CitationsParser.inc.php
@@ -92,7 +92,7 @@ class CitationsParser
 	function getEuropePmcCount($doi)
 	{
 		$ret = array();
-		$url = "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=(REF:".$doi.")";
+		$url = "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=(REF:\"".$doi."\")";
 		$data = $this->getAPIContent($url, 'application/xml');
 		$ret["pmc_count"] = 0;
 		if ($data != null) {

--- a/templates/citations.tpl
+++ b/templates/citations.tpl
@@ -18,7 +18,7 @@
 			</a>
 		</div>
 		<div class="citations-count-pmc">
-			<a href="http://europepmc.org/search?scope=fulltext&query=(REF:{$citationsId})" target="_blank" rel="noreferrer">
+			<a href="http://europepmc.org/search?scope=fulltext&query=(REF:&quot;{$citationsId}&quot;)" target="_blank" rel="noreferrer">
 				<img src="{$citationsImagePath}pmc.png" alt="Europe PMC"/>
 				<br/>
 				<span class="badge_total"></span>


### PR DESCRIPTION
Test searches on http://europepmc.org for 
(REF:10.1186/s42409-018-0003-3) 
3 hits (false)
versus 
(REF:"10.1186/s42409-018-0003-3")
0 hits (correct)
Without quotes, also parial matches of the DOI are found.